### PR TITLE
Add capability to cancel a free call

### DIFF
--- a/alloc_events.h
+++ b/alloc_events.h
@@ -17,7 +17,8 @@ void ALLOC_EVENT(post_init)(void) ALLOC_EVENT_ATTRIBUTES;
 void ALLOC_EVENT(pre_alloc)(size_t *p_size, size_t *p_alignment, const void *caller) ALLOC_EVENT_ATTRIBUTES;
 void ALLOC_EVENT(post_successful_alloc)(void *allocated, size_t modified_size, size_t modified_alignment, 
 	size_t requested_size, size_t requested_alignment, const void *caller) ALLOC_EVENT_ATTRIBUTES;
-void ALLOC_EVENT(pre_nonnull_free)(void *userptr, size_t freed_usable_size) ALLOC_EVENT_ATTRIBUTES;
+// Return non-zero => cancel the free call
+int ALLOC_EVENT(pre_nonnull_free)(void *userptr, size_t freed_usable_size) ALLOC_EVENT_ATTRIBUTES;
 void ALLOC_EVENT(post_nonnull_free)(void *userptr) ALLOC_EVENT_ATTRIBUTES;
 void ALLOC_EVENT(pre_nonnull_nonzero_realloc)(void *userptr, size_t size, const void *caller) ALLOC_EVENT_ATTRIBUTES;
 void ALLOC_EVENT(post_nonnull_nonzero_realloc)(void *userptr, 

--- a/event_hooks.c
+++ b/event_hooks.c
@@ -62,7 +62,7 @@ void hook_free(void *userptr, const void *caller)
 	#ifdef TRACE_MALLOC_HOOKS
 	if (userptr != NULL) fprintf(stderr, "freeing chunk at %p (userptr %p)\n", allocptr, userptr);
 	#endif 
-	if (userptr != NULL) ALLOC_EVENT(pre_nonnull_free)(userptr, malloc_usable_size(allocptr));
+	if (userptr != NULL && ALLOC_EVENT(pre_nonnull_free)(userptr, malloc_usable_size(allocptr))) return;
 	
 	__next_hook_free(allocptr, caller);
 	


### PR DESCRIPTION
This is useful if we need to delay a call to free to later, on some condition detected by the `pre_nonnull_free` hook.