### PR TITLE
hack: workaround for gold bug in file-local initial-exec TLS symbol relocation

### DIFF
--- a/src/terminal-indirect-dlsym.c
+++ b/src/terminal-indirect-dlsym.c
@@ -65,7 +65,9 @@
  * A read is a plain thread-pointer-relative access with no malloc. 
  * Valid as long as we are loaded at program startup (via LD_PRELOAD) and never dlopen'd later.
  */
-static __thread _Bool we_are_active __attribute__((tls_model("initial-exec")));
+// HACK: This needs to be a hidden global and not a static to work around a gold bug
+__attribute__((visibility("hidden"), tls_model("initial-exec")))
+__thread _Bool we_are_active;
 #define ABORT_ON_REENTRANCY do { \
 	_Bool is_reentrant_call = we_are_active; \
 	if (is_reentrant_call) abort(); \


### PR DESCRIPTION
When linking a shared object with gold, access to a `static`__thread` variable that uses the **initial-exec** TLS model apparently can produce a malformed `R_X86_64_TPOFF64` dynamic relocation.

The relocation references a local `.dynsym` entry that gold leaves as `STN_UNDEF`/`NULL`, so the variable's in-block TLS offset (its `st_value`) is lost. At load time, the dynamic loader computes `0 + addend(0) - module_tls_offset`, i.e. the address of **TLS offset 0**, instead of the variable's real offset. 

The variable,  then, is practically an alias for whatever unrelated `__thread` object lives at offset 0 in the module's TLS block.

bfd works fine.

## Gold's bug

The guard `we_are_active` is laid out at TLS offset 0x2020.

`readelf -rW` of the gold-linked shared object:

    Offset            Info              Type             Sym. Value    Sym. + Addend
    0000...725e18  0000000200000012  R_X86_64_TPOFF64  0000000000000000  <null> + 0

The reloc's symbol index is 2, but `.dynsym[2]` is a degenerate entry:

    Num: Value             Size Type   Bind   Vis     Ndx Name
      2: 0000000000000000     0 NOTYPE LOCAL  DEFAULT UND        (empty name)

Meanwhile, `.symtab` has the real symbol with the correct offset:

      ...: 0000000000002020  1 TLS    LOCAL  DEFAULT  17 we_are_active

So gold allocated a local dynamic-symbol slot for the TLS reloc target but never populated it, brilliant.

## Expected (bfd, same objects/flags)

bfd encodes the offset in the relocation addend with no symbol (STN_UNDEF, r_sym 0):

```txt
    Offset            Info              Type             Sym. Value  Sym. + Addend
    0000...724d60  0000000000000012  R_X86_64_TPOFF64                  2020
```

i.e. `TPOFF = 0x2020 - module_tls_offset` resolves correctly.

## Liballocs Crash postmortem

With the bad relocation, the initial-exec access reads TLS offset 0, so `we_are_active` aliases the first `__thread` object in the module's TLS block. If the low byte is non-zero, the guard reads a false positive.

## Workaround

We give the guard a real dynamic symbol by making it **global + hidden** instead of `static`;
gold then references a populated `.dynsym` entry:

```c
    __attribute__((visibility("hidden"), tls_model("initial-exec")))
    __thread _Bool we_are_active;
```